### PR TITLE
Close parrot file after reading into GIF

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,15 +32,12 @@ func main() {
 
 func loadParrotFile() (*gif.GIF, error) {
 	parrotFile, err := os.Open("parrot.gif")
-	// Given that we may have an error, address a potential return here if err is not nil
 	if err != nil {
 		return nil, err
 	}
 	defer parrotFile.Close()
 
-	parrot, err := gif.DecodeAll(parrotFile)
-
-	return parrot, err
+	return gif.DecodeAll(parrotFile)
 }
 
 func makeParrotHandler(overlayWidth, xOffset, yOffset int, parrot *gif.GIF) http.Handler {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,12 @@ func main() {
 
 	flag.Parse()
 
+	parrot := loadParrotFile()
+
+	http.ListenAndServe(*addr, makeParrotHandler(*overlayWidth, *xOffset, *yOffset, parrot))
+}
+
+func loadParrotFile() *gif.GIF {
 	parrotFile, err := os.Open("parrot.gif")
 	if err != nil {
 		panic(err)
@@ -33,7 +39,7 @@ func main() {
 		panic(err)
 	}
 
-	http.ListenAndServe(*addr, makeParrotHandler(*overlayWidth, *xOffset, *yOffset, parrot))
+	return parrot
 }
 
 func makeParrotHandler(overlayWidth, xOffset, yOffset int, parrot *gif.GIF) http.Handler {

--- a/main.go
+++ b/main.go
@@ -22,24 +22,25 @@ func main() {
 
 	flag.Parse()
 
-	parrot := loadParrotFile()
+	parrot, err := loadParrotFile()
+	if err != nil {
+		panic(err)
+	}
 
 	http.ListenAndServe(*addr, makeParrotHandler(*overlayWidth, *xOffset, *yOffset, parrot))
 }
 
-func loadParrotFile() *gif.GIF {
+func loadParrotFile() (*gif.GIF, error) {
 	parrotFile, err := os.Open("parrot.gif")
+	// Given that we may have an error, address a potential return here if err is not nil
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	defer parrotFile.Close()
 
 	parrot, err := gif.DecodeAll(parrotFile)
-	if err != nil {
-		panic(err)
-	}
 
-	return parrot
+	return parrot, err
 }
 
 func makeParrotHandler(overlayWidth, xOffset, yOffset int, parrot *gif.GIF) http.Handler {


### PR DESCRIPTION
Adding a function used exclusively for loading and decoding the parrot.gif file to allow closing of the file reference using the `defer parrotFile.Close()`, since the old location within the `main()` function kept the file open until the function closed.

Closes #2 