### PR TITLE
Adding an argument flag for file, defaulting to parrot.gif

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,11 +19,11 @@ func main() {
 	overlayWidth := flag.Int("overlayWidth", 80, "width of image overlay")
 	xOffset := flag.Int("xOffset", 16, "x offset of image overlay")
 	yOffset := flag.Int("yOffset", 20, "y offset of image overlay")
-	fileLocation := flag.String("file", "parrot.gif", "location of parrot file")
+	parrotPath := flag.String("parrotPath", "parrot.gif", "location of parrot file (.gif)")
 
 	flag.Parse()
 
-	parrot, err := loadParrotFile(*fileLocation)
+	parrot, err := loadParrotFile(*parrotPath)
 	if err != nil {
 		panic(err)
 	}
@@ -31,8 +31,8 @@ func main() {
 	http.ListenAndServe(*addr, makeParrotHandler(*overlayWidth, *xOffset, *yOffset, parrot))
 }
 
-func loadParrotFile(fileLocation string) (*gif.GIF, error) {
-	parrotFile, err := os.Open(fileLocation)
+func loadParrotFile(path string) (*gif.GIF, error) {
+	parrotFile, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -19,10 +19,11 @@ func main() {
 	overlayWidth := flag.Int("overlayWidth", 80, "width of image overlay")
 	xOffset := flag.Int("xOffset", 16, "x offset of image overlay")
 	yOffset := flag.Int("yOffset", 20, "y offset of image overlay")
+	fileLocation := flag.String("file", "parrot.gif", "location of parrot file")
 
 	flag.Parse()
 
-	parrot, err := loadParrotFile()
+	parrot, err := loadParrotFile(*fileLocation)
 	if err != nil {
 		panic(err)
 	}
@@ -30,8 +31,8 @@ func main() {
 	http.ListenAndServe(*addr, makeParrotHandler(*overlayWidth, *xOffset, *yOffset, parrot))
 }
 
-func loadParrotFile() (*gif.GIF, error) {
-	parrotFile, err := os.Open("parrot.gif")
+func loadParrotFile(fileLocation string) (*gif.GIF, error) {
+	parrotFile, err := os.Open(fileLocation)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding an optional flag, `file`, that defaults to `parrot.gif` if not defined.

Tested by running 3 scenarios:

1. Test without flag defined, ensure `parrot.gif` is loaded
2. Test with flag defined, valid file location provided, and ensure file is loaded
3. Test with flag defined, invalid file location provided, and ensure server properly panics

Closes #6 